### PR TITLE
Fix compilation on OSX

### DIFF
--- a/getdns.c
+++ b/getdns.c
@@ -47,6 +47,8 @@
 #include "pygetdns.h"
 
 
+PyObject *getdns_error;
+
 
 PyMethodDef Context_methods[] = {
     { "get_api_information", (PyCFunction)context_get_api_information,

--- a/pygetdns.h
+++ b/pygetdns.h
@@ -39,7 +39,7 @@
 # define UNUSED_PARAM(x) ((void)(x))
 #endif
 
-PyObject *getdns_error;
+extern PyObject *getdns_error;
 
 typedef struct pygetdns_libevent_callback_data  {
     void *userarg;


### PR DESCRIPTION
Compilation fails on OSX with the following error:

```
duplicate symbol _getdns_error in:
    build/temp.macosx-10.9-intel-2.7/getdns.o
    build/temp.macosx-10.9-intel-2.7/pygetdns_util.o
duplicate symbol _getdns_error in:
    build/temp.macosx-10.9-intel-2.7/getdns.o
    build/temp.macosx-10.9-intel-2.7/fd_poller.o
duplicate symbol _getdns_error in:
    build/temp.macosx-10.9-intel-2.7/getdns.o
    build/temp.macosx-10.9-intel-2.7/context.o
ld: 3 duplicate symbols for architecture x86_64
```

This PR fixes it by making getdns.c the only compilation target.
