### PR TITLE
Remove internal PyCapsule objects

### DIFF
--- a/getdns.c
+++ b/getdns.c
@@ -158,7 +158,7 @@ PyTypeObject getdns_ResultType = {
     0,                         /* tp_descr_get */
     0,                         /* tp_descr_set */
     0,                         /* tp_dictoffset */
-    (initproc)result_init,      /* tp_init */
+    0,                         /* tp_init */
     0,                         /* tp_alloc */
     PyType_GenericNew,                 /* tp_new */
 };

--- a/pygetdns.h
+++ b/pygetdns.h
@@ -72,7 +72,7 @@ typedef struct  {
 
 typedef struct {
     PyObject_HEAD
-    PyObject *py_context;       /* Python capsule containing getdns_context */
+    getdns_context* context;
     uint64_t  timeout;          /* timeout attribute (milliseconds) */
     uint64_t  idle_timeout;     /* TCP timeout attribute (milliseconds) */
     getdns_resolution_t resolution_type; /* stub or recursive? */
@@ -111,7 +111,6 @@ struct setter_table  {          /* we're now using bsearch to find */
 extern PyTypeObject getdns_ResultType;
 void result_dealloc(getdns_ResultObject *self);
 extern PyObject *result_getattro(PyObject *self, PyObject *nameobj);
-PyObject *py_result(PyObject *result_capsule);
 PyObject *result_create(struct getdns_dict *resp);
 PyObject *result_str(PyObject *self);
 
@@ -167,7 +166,6 @@ PyObject *get_callback(char *py_main, char *callback);
 void callback_shim(struct getdns_context *context, getdns_callback_type_t type,
                    struct getdns_dict *response, void *userarg, getdns_transaction_t tid);
 
-int result_init(getdns_ResultObject *self, PyObject *args, PyObject *keywds);
 PyObject *result_getattro(PyObject *self, PyObject *nameobj);
 int result_setattro(PyObject *self, PyObject *attrname, PyObject *value);
 

--- a/result.c
+++ b/result.c
@@ -41,24 +41,12 @@
 #endif
 
 int
-result_init(getdns_ResultObject *self, PyObject *args, PyObject *keywds)
+result_init(getdns_ResultObject *self, getdns_dict *result_dict)
 {
-    PyObject *result_capsule;
-    struct getdns_dict *result_dict;
     int  status;
     int  answer_type;
     char *canonical_name;
 
-    if (!PyArg_ParseTuple(args, "|O", &result_capsule))  {
-        PyErr_SetString(PyExc_AttributeError, GETDNS_RETURN_INVALID_PARAMETER_TEXT);
-        Py_DECREF(self);
-        return -1;
-    }
-    if ((result_dict = PyCapsule_GetPointer(result_capsule, "result")) == NULL)  {
-        PyErr_SetString(PyExc_AttributeError, "Unable to initialize result object");
-        Py_DECREF(self);
-        return -1;
-    }
     if ((self->replies_full = gdict_to_pdict(result_dict)) == NULL)  {
         Py_DECREF(self);
         return -1;
@@ -186,10 +174,9 @@ result_str(PyObject *self)
 PyObject *
 result_create(struct getdns_dict *resp)
 {
-    PyObject *result_capsule;
-    PyObject *args;
-
-    result_capsule = PyCapsule_New(resp, "result", 0);
-    args = Py_BuildValue("(O)", result_capsule);
-    return PyObject_CallObject((PyObject *)&getdns_ResultType, args);
+    PyObject *result = PyObject_CallObject((PyObject *)&getdns_ResultType, NULL);
+    if (result_init((getdns_ResultObject*)result, resp) < 0) {
+        return NULL;
+    }
+    return result;
 }


### PR DESCRIPTION
They are not needed since they are not exposed to userland Python code,
so embed pointers to the right C structured in the PyObject type.


PS: @MelindaShore this PR goes agains the 'develop' branch.