### PR TITLE
Fix refcount handling for None object

### DIFF
--- a/context_util.c
+++ b/context_util.c
@@ -87,8 +87,11 @@ callback_shim(struct getdns_context *context,
     }
     if (type == GETDNS_CALLBACK_CANCEL)  {
         py_result = Py_None;
+        Py_INCREF(Py_None);
         py_tid = Py_None;
+        Py_INCREF(Py_None);
         py_userarg = Py_None;
+        Py_INCREF(Py_None);
     }  else  {
         py_result = result_create(response);
 #if PY_MAJOR_VERSION >= 3
@@ -96,14 +99,16 @@ callback_shim(struct getdns_context *context,
 #else
         py_tid = PyInt_FromLong((long)tid);
 #endif
-        if (u->userarg)
+        if (u->userarg) {
 #if PY_MAJOR_VERSION >= 3
             py_userarg = PyUnicode_FromString(u->userarg);
 #else
             py_userarg = PyString_FromString(u->userarg);
 #endif
-        else
+        } else {
             py_userarg = Py_None;
+            Py_INCREF(Py_None);
+        }
     }
     PyObject_CallFunctionObjArgs(u->callback_func, py_callback_type, py_result, py_userarg, py_tid, NULL);
 }

--- a/getdns.c
+++ b/getdns.c
@@ -370,8 +370,8 @@ get_errorstr_by_id(PyObject *self, PyObject *args, PyObject *keywds)
         PyErr_SetString(getdns_error, GETDNS_RETURN_INVALID_PARAMETER_TEXT);
         return NULL;
     }
-    if ((errstr = (char *)getdns_get_errorstr_by_id((uint16_t)id)) == 0) 
-        return Py_None;
+    if ((errstr = (char *)getdns_get_errorstr_by_id((uint16_t)id)) == 0)
+        Py_RETURN_NONE;
     else
 #if PY_MAJOR_VERSION >= 3
         return PyUnicode_FromString(errstr);

--- a/result.c
+++ b/result.c
@@ -85,25 +85,34 @@ result_init(getdns_ResultObject *self, PyObject *args, PyObject *keywds)
 #else
     self->answer_type = PyInt_FromLong((long)answer_type);
 #endif
-    if ((canonical_name = get_canonical_name(result_dict)) == 0)  
+    if ((canonical_name = get_canonical_name(result_dict)) == 0) {
         self->canonical_name = Py_None;
-    else
+        Py_INCREF(Py_None);
+    } else {
 #if PY_MAJOR_VERSION >= 3
         self->canonical_name = PyUnicode_FromString(canonical_name);
 #else
         self->canonical_name = PyString_FromString(canonical_name);
 #endif
+    }
     if ((self->just_address_answers = get_just_address_answers(result_dict)) == NULL)  {
         self->just_address_answers = Py_None;
+        Py_INCREF(Py_None);
     }
-    if ((self->validation_chain = get_validation_chain(result_dict)) == NULL)  
+    if ((self->validation_chain = get_validation_chain(result_dict)) == NULL) {
         self->validation_chain = Py_None;
+        Py_INCREF(Py_None);
+    }
 #if GETDNS_NUMERIC_VERSION < 0x00090000
-    if ((self->call_debugging = get_call_debugging(result_dict)) == NULL)
+    if ((self->call_debugging = get_call_debugging(result_dict)) == NULL) {
         self->call_debugging = Py_None;
+        Py_INCREF(Py_None);
+    }
 #else
-    if ((self->call_reporting = get_call_reporting(result_dict)) == NULL)
+    if ((self->call_reporting = get_call_reporting(result_dict)) == NULL) {
         self->call_reporting = Py_None;
+        Py_INCREF(Py_None);
+    }
 #endif
     return 0;
 }
@@ -117,16 +126,25 @@ result_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     self = (getdns_ResultObject *)type->tp_alloc(type, 0);
     if (self != NULL)  {
         self->just_address_answers = Py_None;
+        Py_INCREF(Py_None);
         self->answer_type = Py_None;
+        Py_INCREF(Py_None);
         self->status = Py_None;
+        Py_INCREF(Py_None);
         self->replies_tree = Py_None;
+        Py_INCREF(Py_None);
         self->canonical_name = Py_None;
+        Py_INCREF(Py_None);
         self->replies_full = Py_None;
+        Py_INCREF(Py_None);
         self->validation_chain = Py_None;
+        Py_INCREF(Py_None);
 #if GETDNS_NUMERIC_VERSION < 0x00090000
         self->call_debugging = Py_None;
+        Py_INCREF(Py_None);
 #else
         self->call_reporting = Py_None;
+        Py_INCREF(Py_None);
 #endif
     }
     return (PyObject *)self;


### PR DESCRIPTION
Py_None is a singleton, but its refcount has to be managed like a
regular object, that, it needs to be Py_INCREF'd before returning it or
assigning it to a structure and it needs to be Py_DECREF'd when the
containing object goes away.