### PR TITLE
Fix compilation in Python 3.x environments

### DIFF
--- a/getdns.c
+++ b/getdns.c
@@ -333,10 +333,17 @@ wire_to_dict(PyObject *self, PyObject *args, PyObject *keywds)
         PyErr_SetString(getdns_error, GETDNS_RETURN_INVALID_PARAMETER_TEXT);
         return NULL;
     }
+#if PY_MAJOR_VERSION >= 3
+    if (!PyObject_CheckBuffer(py_wirebuf))  {
+        PyErr_SetString(getdns_error, GETDNS_RETURN_GENERIC_ERROR_TEXT);
+        return NULL;
+    }
+#else
     if (!PyBuffer_Check(py_wirebuf))  {
         PyErr_SetString(getdns_error, GETDNS_RETURN_GENERIC_ERROR_TEXT);
         return NULL;
     }
+#endif
     if ((view = (Py_buffer *)malloc(sizeof(*view))) == NULL)  {
         PyErr_SetString(getdns_error, GETDNS_RETURN_GENERIC_ERROR_TEXT);
         return NULL;


### PR DESCRIPTION
Commit 86111d97badaf1c4f9e73583bd637b4977372fd6 seems to break Python 3 compatibility

Current behavior on develop (HEAD)
lsb_release: Ubuntu 14.04.2 LTS
# python --version
Python 3.5.2

$ make
x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security -D_FORTIFY_SOURCE=2 -fPIC -I/usr/local/include -I/usr/include/python3.5m -I/srv/venv35/include/python3.5m -c getdns.c -o build/temp.linux-x86_64-3.5/getdns.o -g
getdns.c: In function ‘wire_to_dict’:
getdns.c:336:5: warning: implicit declaration of function ‘PyBuffer_Check’ [-Wimplicit-function-declaration]
     if (!PyBuffer_Check(py_wirebuf))  {