### PR TITLE
getdns.file_to_list implementation

### DIFF
--- a/test/example.com.zone
+++ b/test/example.com.zone
@@ -1,0 +1,14 @@
+example.com.    IN  SOA ns1.example.com.    hostmaster.example.com. (
+                2016111300
+                3600
+                900
+                1814400
+                3600    )
+
+                IN  NS      ns1.example.com.
+                IN  NS      ns2.example.com.
+
+ns1             IN  A       192.0.2.1
+                IN  AAAA    2001:DB8::1
+ns2             IN  A       192.0.2.1
+                IN  AAAA    2001:DB8::2

--- a/test/getdns_test.py
+++ b/test/getdns_test.py
@@ -1,0 +1,46 @@
+import unittest
+import getdns
+
+class TestGetdnsMethods(unittest.TestCase):
+
+    def test_context(self):
+        c = getdns.Context()
+        self.assertIsNotNone(c)
+        del(c)
+
+    def test_sync_address(self):
+        c = getdns.Context()
+        c.resolution_type=getdns.RESOLUTION_STUB
+        r = c.address('www.getdnsapi.net')
+        self.assertEqual(r.status, getdns.RESPSTATUS_GOOD)
+        self.assertTrue('185.49.141.37' in [ x['address_data'] for x in r.just_address_answers ])
+        del(c)
+        del(r)
+
+    def test_sync_service(self):
+        c = getdns.Context()
+        c.resolution_type=getdns.RESOLUTION_STUB
+        r = c.service('_xmpp-server._tcp.jabber.org')
+        self.assertEqual(r.status, getdns.RESPSTATUS_GOOD)
+        del(c)
+        del(r)
+
+    def test_sync_hostname(self):
+        c = getdns.Context()
+        c.resolution_type=getdns.RESOLUTION_STUB
+        r = c.hostname( { 'address_type': 'IPv4', 'address_data': '185.49.141.37' } )
+        self.assertEqual(r.status, getdns.RESPSTATUS_GOOD)
+        del(c)
+        del(r)
+
+    def test_sync_general(self):
+        c = getdns.Context()
+        c.resolution_type=getdns.RESOLUTION_STUB
+        r = c.general('nlnetlabs.nl', request_type=getdns.RRTYPE_NS)
+        self.assertEqual(r.status, getdns.RESPSTATUS_GOOD)
+        del(c)
+        del(r)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/getdns_test.py
+++ b/test/getdns_test.py
@@ -1,8 +1,9 @@
-import unittest
 import getdns
+import inspect
+import StringIO
+import unittest
 
 class TestGetdnsMethods(unittest.TestCase):
-
     def test_context(self):
         c = getdns.Context()
         self.assertIsNotNone(c)
@@ -39,6 +40,29 @@ class TestGetdnsMethods(unittest.TestCase):
         r = c.general('nlnetlabs.nl', request_type=getdns.RRTYPE_NS)
         self.assertEqual(r.status, getdns.RESPSTATUS_GOOD)
         del(c)
+        del(r)
+
+    def test_file_to_list(self):
+        ns1 = {'class': 1,
+               'name': 'example.com.',
+               'rdata': {'nsdname': 'ns1.example.com.',
+                         'rdata_raw':'ns1.example.com.'},
+               'ttl': 3600,
+               'type': 2
+               }
+        ns2 = {'class': 1,
+               'name': 'example.com.',
+               'rdata': {'nsdname': 'ns2.example.com.',
+                         'rdata_raw': 'ns2.example.com.'},
+               'ttl': 3600,
+               'type': 2
+               }
+        f = open('example.com.zone')
+        r = getdns.file_to_list(f, 'example.com', 3600 )
+        self.assertIsInstance(r, list)
+        self.assertEqual(r[1], ns1)
+        self.assertEqual(r[2], ns2)
+        del(f)
         del(r)
 
 


### PR DESCRIPTION
I wanted to actually test that the whole list matched the original zone file, but the raw data in the nested structure for the SOA and A records made that impossible. So instead, I just test that the 2nd and 3rd records are the expected NS records.